### PR TITLE
Bugfix: Logout Race Conditions

### DIFF
--- a/BombersRTT/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BombersRTT/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -517,7 +517,7 @@ using UnityEngine.Experimental.Networking;
                         ResetIdleTimer();
                         HandleResponseBundle(GetWebRequestResponse(_activeRequest));
                         DisposeUploadHandler();
-                        _activeRequest = null;        
+                        _activeRequest = null;
                     }
                     //HttpStatusCode.ServiceUnavailable
                     else if (_activeRequest.WebRequest.responseCode == 503)

--- a/BombersRTT/Assets/Framework/BaseManagers/GCore.cs
+++ b/BombersRTT/Assets/Framework/BaseManagers/GCore.cs
@@ -73,7 +73,7 @@ namespace Gameframework
         {
             IsFreshLaunch = true;
             GPlayerMgr.Instance.ResetBrainCloudAuth();
-            GStateManager.Instance.PopAllSubStatesTo(""); // clear all substates
+            GStateManager.Instance.ClearAllSubStates(); // clear all substates
         }
         #endregion
 
@@ -99,9 +99,13 @@ namespace Gameframework
             GStateManager.Instance.EnableLoadingSpinner(false);
             switch (reasonCode)
             {
+                case ReasonCodes.NO_SESSION:
+                    {
+                        if (IsFreshLaunch) break; // Prevent race condition where popup can appear and causes a softlock
+                        goto case ReasonCodes.PLAYER_SESSION_LOGGED_OUT;
+                    }
                 case ReasonCodes.UNABLE_TO_VALIDATE_PLAYER:
                 case ReasonCodes.PLAYER_SESSION_EXPIRED:
-                case ReasonCodes.NO_SESSION:
                 case ReasonCodes.PLAYER_SESSION_LOGGED_OUT:
                     {
                         HudHelper.DisplayMessageDialog("SESSION EXPIRED", "YOUR SESSION HAS EXPIRED. RE-AUTHENTICATING...", "OK", OnSessionExpiredDialogClose);

--- a/BombersRTT/Assets/Framework/BaseManagers/GCore.cs
+++ b/BombersRTT/Assets/Framework/BaseManagers/GCore.cs
@@ -101,7 +101,7 @@ namespace Gameframework
             {
                 case ReasonCodes.NO_SESSION:
                     {
-                        if (IsFreshLaunch) break; // Prevent race condition where popup can appear and causes a softlock
+                        if (IsFreshLaunch) break; // Prevent race condition where this popup can appear and causes a softlock
                         goto case ReasonCodes.PLAYER_SESSION_LOGGED_OUT;
                     }
                 case ReasonCodes.UNABLE_TO_VALIDATE_PLAYER:

--- a/BombersRTT/Assets/Scenes/SubStates/MainOptions/MainOptionsSubState.cs
+++ b/BombersRTT/Assets/Scenes/SubStates/MainOptions/MainOptionsSubState.cs
@@ -342,13 +342,12 @@ namespace BrainCloudUNETExample
 
         private void onLogout()
         {
-            GCore.Wrapper.PlayerStateService.Logout(onPlayerLoggedOut);
+            GCore.Wrapper.RTTService.DisableRTT();
+            GCore.Wrapper.PlayerStateService.Logout(onPlayerLoggedOut, BombersNetworkManager.Instance.OnEnableRTTFailed);
         }
 
         private void onPlayerLoggedOut(string in_str, object obj)
         {
-            GCore.IsFreshLaunch = true;
-
             HudHelper.DisplayMessageDialog("LOGGED OUT", "YOU HAVE BEEN LOGGED OUT.",
                 "OK", onLoggedOut);
         }

--- a/BombersRTT/Assets/Scenes/SubStates/MainOptions/MainOptionsSubState.cs
+++ b/BombersRTT/Assets/Scenes/SubStates/MainOptions/MainOptionsSubState.cs
@@ -347,6 +347,8 @@ namespace BrainCloudUNETExample
 
         private void onPlayerLoggedOut(string in_str, object obj)
         {
+            GCore.IsFreshLaunch = true;
+
             HudHelper.DisplayMessageDialog("LOGGED OUT", "YOU HAVE BEEN LOGGED OUT.",
                 "OK", onLoggedOut);
         }

--- a/BombersRTT/Assets/Scripts/Networking/BombersNetworkManager.cs
+++ b/BombersRTT/Assets/Scripts/Networking/BombersNetworkManager.cs
@@ -1,6 +1,4 @@
-﻿
-
-using UnityEngine;
+﻿using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
 using System;
@@ -1108,8 +1106,6 @@ namespace BrainCloudUNETExample
 
         public void OnEnableRTTFailed(int statusCode, int reasonCode, string in_stringData, object in_obj)
         {
-            if(GCore.IsFreshLaunch) return; // Race condition where this can be called, interrupting the logout process
-
             GStateManager.Instance.EnableLoadingSpinner(false);
             HudHelper.DisplayMessageDialog("IDLE TIMEOUT", "ARE YOU STILL THERE?", "YES!", onReconnectRTT);
         }

--- a/BombersRTT/Assets/Scripts/Networking/BombersNetworkManager.cs
+++ b/BombersRTT/Assets/Scripts/Networking/BombersNetworkManager.cs
@@ -1108,6 +1108,8 @@ namespace BrainCloudUNETExample
 
         public void OnEnableRTTFailed(int statusCode, int reasonCode, string in_stringData, object in_obj)
         {
+            if(GCore.IsFreshLaunch) return; // Race condition where this can be called, interrupting the logout process
+
             GStateManager.Instance.EnableLoadingSpinner(false);
             HudHelper.DisplayMessageDialog("IDLE TIMEOUT", "ARE YOU STILL THERE?", "YES!", onReconnectRTT);
         }


### PR DESCRIPTION
-  Fixed a bug where RTTComms can softlock the app on logout
-  Fixed a bug where error `NO_SESSION (40304)` can appear after the app has logged out but is still loading the MainMenu; this causes a softlock were the error popup cannot be closed