### PR TITLE
BCLOUD 3951 end match implementation

### DIFF
--- a/RelayTestApp/Assets/ArtAssets/circle.mat
+++ b/RelayTestApp/Assets/ArtAssets/circle.mat
@@ -2,15 +2,18 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: circle
-  m_Shader: {fileID: 202, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
-  m_LightmapFlags: 4
+  m_Shader: {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords:
+  - _ALPHABLEND_ON
+  - _FADING_ON
+  m_LightmapFlags: 0
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
@@ -55,26 +58,51 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
+    - _BlendOp: 0
     - _BumpScale: 1
+    - _CameraFadingEnabled: 0
+    - _CameraFarFadeDistance: 2
+    - _CameraNearFadeDistance: 1
+    - _ColorMask: 15
+    - _Cull: 0
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DistortionBlend: 0.5
+    - _DistortionEnabled: 0
+    - _DistortionStrength: 1
+    - _DistortionStrengthScaled: 0
+    - _DstBlend: 1
+    - _EmissionEnabled: 0
+    - _FlipbookMode: 0
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _InvFade: 1
+    - _InvFade: 0.98
+    - _LightingEnabled: 1
     - _Metallic: 0
-    - _Mode: 0
+    - _Mode: 4
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
+    - _SoftParticlesEnabled: 1
+    - _SoftParticlesFarFadeDistance: 1
+    - _SoftParticlesNearFadeDistance: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 1
+    - _SrcBlend: 5
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
     - _UVSec: 0
-    - _ZWrite: 1
+    - _UseUIAlphaClip: 0
+    - _ZWrite: 0
     m_Colors:
+    - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _TintColor: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
+    - _SoftParticleFadeParams: {r: 0, g: 1, b: 0, a: 0}
+    - _TintColor: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/BrainCloudRelay.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/BrainCloudRelay.cs
@@ -129,9 +129,9 @@ using BrainCloud.Internal;
             m_commsLayer.Disconnect();
         }
 
-        public void EndMatch()
+        public void EndMatch(Dictionary<string, object> json)
         {
-            m_commsLayer.EndMatch();
+            m_commsLayer.EndMatch(json);
         }
 
         /// <summary>

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/BrainCloudRelay.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/BrainCloudRelay.cs
@@ -129,6 +129,11 @@ using BrainCloud.Internal;
             m_commsLayer.Disconnect();
         }
 
+        public void EndMatch()
+        {
+            m_commsLayer.EndMatch();
+        }
+
         /// <summary>
         /// Is Connected
         /// </summary>

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
@@ -655,7 +655,7 @@ namespace BrainCloud.Internal
             {
                 if (m_endMatchRequested)
                 {
-                    m_clientRef.Log("Relay: Connection closed by host");
+                    m_clientRef.Log("Relay: Connection closed by end match");
                 }
                 else
                 {

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
@@ -32,12 +32,14 @@ namespace BrainCloud.Internal
         public const byte CL2RS_ACK = 3;
         public const byte CL2RS_PING = 4;
         public const byte CL2RS_RSMG_ACK = 5;
+        public const byte CL2RS_ENDMATCH = 6;
 
         public const byte RS2CL_RSMG = 0;
         public const byte RS2CL_DISCONNECT = 1;
         public const byte RS2CL_RELAY = 2;
         public const byte RS2CL_ACK = 3;
         public const byte RS2CL_PONG = 4;
+        public const byte RS2CL_ENDMATCH = 6;
         #endregion
 
         private const int MAX_RSMG_HISTORY = 50;
@@ -87,6 +89,7 @@ namespace BrainCloud.Internal
             Ping = 999;
             if (!IsConnected())
             {
+                m_endMatchRequested = false;
                 // the callback
                 m_connectOptions = in_options;
                 m_connectedSuccessCallback = in_success;
@@ -106,6 +109,19 @@ namespace BrainCloud.Internal
         {
             if (IsConnected()) send(buildDisconnectRequest());
             disconnect();
+        }
+
+        public void EndMatch()
+        {
+            if (IsConnected())
+            {
+                Dictionary<string, object> json = new Dictionary<string, object>();
+                json["cxId"] = m_clientRef.RTTConnectionID;
+                json["lobbyId"] = m_connectOptions.lobbyId;
+                json["op"] = "END_MATCH";
+                send(buildEndMatchRequest(json));
+                m_endMatchRequested = true;
+            }
         }
 
         /// <summary>
@@ -371,7 +387,9 @@ namespace BrainCloud.Internal
                             }
                             break;
                         case EventType.ConnectFailure:
-                            if (m_connectionFailureCallback != null)
+                            //When End Match is requested, then the server will close the connection
+                            if (m_connectionFailureCallback != null && 
+                                !m_endMatchRequested)
                             {
                                 eventsCopy.Clear();
                                 lock (m_events)
@@ -436,6 +454,12 @@ namespace BrainCloud.Internal
             return array;
         }
 
+        private byte[] buildEndMatchRequest(Dictionary<string, object> in_jsonPayload)
+        {
+            byte[] array = concatenateByteArrays(ENDMATCH_ARR, Encoding.ASCII.GetBytes(m_clientRef.SerializeJson(in_jsonPayload)));
+            return array;
+        }
+
         private string buildRSRequestError(string in_statusMessage)
         {
             Dictionary<string, object> json = new Dictionary<string, object>();
@@ -451,7 +475,6 @@ namespace BrainCloud.Internal
         {
             return DISCONNECT_ARR;
         }
-
 
         /// <summary>
         /// 
@@ -470,25 +493,28 @@ namespace BrainCloud.Internal
             m_ownerCxId = "";
             m_netId = INVALID_NET_ID;
 
-            if (m_webSocket != null) m_webSocket.Close();
-            m_webSocket = null;
-
-            if (m_tcpStream != null)
+            if (!m_endMatchRequested)
             {
-                m_tcpStream.Dispose();
-            }
-            m_tcpStream = null;
+                if (m_webSocket != null) m_webSocket.Close();
+                m_webSocket = null;
 
-            if (m_tcpClient != null)
-            {
-                m_tcpClient.Client.Close(0);
-                m_tcpClient.Close();
-                fToSend.Clear();
-            }
-            m_tcpClient = null;
+                if (m_tcpStream != null)
+                {
+                    m_tcpStream.Dispose();
+                }
+                m_tcpStream = null;
 
-            if (m_udpClient != null) m_udpClient.Close();
-            m_udpClient = null;
+                if (m_tcpClient != null)
+                {
+                    m_tcpClient.Client.Close(0);
+                    m_tcpClient.Close();
+                    fToSend.Clear();
+                }
+                m_tcpClient = null;
+
+                if (m_udpClient != null) m_udpClient.Close();
+                m_udpClient = null;   
+            }
 
             // cleanup UDP stuff
             m_sendPacketId.Clear();
@@ -775,6 +801,12 @@ namespace BrainCloud.Internal
                         }
                         break;
                     }
+                case "END_MATCH":
+                {
+                    m_endMatchRequested = true;
+                    disconnect();
+                    break;
+                }
             }
 
             queueSystemEvent(jsonMessage);
@@ -1079,10 +1111,6 @@ namespace BrainCloud.Internal
 
         private void tcpFinishWrite(IAsyncResult result)
         {
-            if (result.IsCompleted)
-            {
-                return;
-            }
             try
             {
                 if (m_tcpClient != null)
@@ -1441,6 +1469,7 @@ namespace BrainCloud.Internal
         // end 
 
         private bool m_resendConnectRequest = false;
+        private bool m_endMatchRequested;
         private DateTime m_lastConnectResendTime = DateTime.Now;
 
         private const int CONTROL_BYTE_HEADER_LENGTH = 1;
@@ -1453,6 +1482,7 @@ namespace BrainCloud.Internal
         private long m_sentPing = DateTime.Now.Ticks;
         private byte[] DISCONNECT_ARR = { CL2RS_DISCONNECT };
         private byte[] CONNECT_ARR = { CL2RS_CONNECT };
+        private byte[] ENDMATCH_ARR = { CL2RS_ENDMATCH };
 
         // success callbacks
         private SuccessCallback m_connectedSuccessCallback = null;

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/Internal/RelayComms.cs
@@ -653,7 +653,15 @@ namespace BrainCloud.Internal
         {
             if (m_clientRef.LoggingEnabled)
             {
-                m_clientRef.Log("Relay: Connection closed: " + reason);
+                if (m_endMatchRequested)
+                {
+                    m_clientRef.Log("Relay: Connection closed by host");
+                }
+                else
+                {
+                    m_clientRef.Log("Relay: Connection closed: " + reason);    
+                }
+                
             }
             queueErrorEvent(reason);
         }

--- a/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
+++ b/RelayTestApp/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
@@ -615,6 +615,7 @@ namespace BrainCloud
         public const int RS_CLIENT_ERROR = 90300;
         public const int JSON_REQUEST_MAXDEPTH_EXCEEDS_LIMIT = 90400;
         public const int JSON_RESPONSE_MAXDEPTH_EXCEEDS_LIMIT = 90401;
+        public const int RS_ENDMATCH_REQUESTED = 90500;
         public const int CHILD_USER_MISSING = CHILD_PLAYER_MISSING;
         public const int DISABLED_APP = DISABLED_GAME;
         public const int APPS_NOT_IN_SAME_COMPANY = GAMES_NOT_IN_SAME_COMPANY;

--- a/RelayTestApp/Assets/Prefabs/Shockwave - Particle.prefab
+++ b/RelayTestApp/Assets/Prefabs/Shockwave - Particle.prefab
@@ -28,6 +28,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -39,19 +40,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2255982038416346491}
-  serializedVersion: 7
+  serializedVersion: 8
   lengthInSec: 1
   simulationSpeed: 2
   stopAction: 2
   cullingMode: 0
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 0
   looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -222,7 +223,7 @@ ParticleSystem:
       serializedVersion: 2
       minMaxState: 0
       minColor: {r: 1, g: 1, b: 1, a: 1}
-      maxColor: {r: 0.93333334, g: 0.87096465, b: 0.28627446, a: 1}
+      maxColor: {r: 0, g: 0, b: 0, a: 1}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -601,6 +602,7 @@ ParticleSystem:
         m_RotationOrder: 4
     randomizeRotationDirection: 0
     maxNumParticles: 1
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -4750,6 +4752,7 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
@@ -4780,6 +4783,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 2
   m_RenderMode: 0
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0
   m_MaxParticleSize: 0.5
@@ -4794,7 +4798,7 @@ ParticleSystemRenderer:
   m_Flip: {x: 0, y: 0, z: 0}
   m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 1
-  m_ApplyActiveColorSpace: 1
+  m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
   m_FreeformStretching: 0
   m_RotateWithStretchDirection: 1
@@ -4803,4 +4807,8 @@ ParticleSystemRenderer:
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0

--- a/RelayTestApp/Assets/Prefabs/UserEntryMatch -TextToggle.prefab
+++ b/RelayTestApp/Assets/Prefabs/UserEntryMatch -TextToggle.prefab
@@ -27,6 +27,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -6912.0005}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4362776453284123397}
   - {fileID: 6340734714419388287}
@@ -81,14 +82,15 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4362776453284123395}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.53, y: -5.69}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchoredPosition: {x: 154.6, y: -5.69}
+  m_SizeDelta: {x: 500, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4362776453284123392
 CanvasRenderer:
@@ -215,6 +217,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 9860861403756541}
   m_RootOrder: 0
@@ -290,6 +293,7 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7216745878492647249}
   m_Father: {fileID: 6340734714419388287}
@@ -366,6 +370,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9860861403756541}
   m_Father: {fileID: 4362776453284123395}

--- a/RelayTestApp/Assets/Scenes/main.unity
+++ b/RelayTestApp/Assets/Scenes/main.unity
@@ -212,6 +212,141 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &63417908
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 63417909}
+  - component: {fileID: 63417911}
+  - component: {fileID: 63417910}
+  m_Layer: 5
+  m_Name: StartButton-Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &63417909
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63417908}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1945819038}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &63417910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63417908}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Join Match
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 34.22
+  m_fontSizeBase: 34.22
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &63417911
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63417908}
+  m_CullTransparentMesh: 1
 --- !u!1 &83217797
 GameObject:
   m_ObjectHideFlags: 0
@@ -303,8 +438,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 786, y: -822.5}
-  m_SizeDelta: {x: 156.59998, y: 60}
+  m_AnchoredPosition: {x: 715, y: -822.5}
+  m_SizeDelta: {x: 250, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &93820290
 MonoBehaviour:
@@ -2263,7 +2398,7 @@ RectTransform:
   - {fileID: 819777836}
   - {fileID: 365192646}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2514,7 +2649,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Start
+  m_text: Start Match
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3385,7 +3520,7 @@ RectTransform:
   - {fileID: 1083399684}
   - {fileID: 323421866}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4815,6 +4950,8 @@ RectTransform:
   - {fileID: 1826973928}
   - {fileID: 1871200857}
   - {fileID: 1200279226}
+  - {fileID: 1633334062}
+  - {fileID: 2034033204}
   - {fileID: 2147185985}
   - {fileID: 676101745}
   - {fileID: 1145382223}
@@ -4865,7 +5002,7 @@ RectTransform:
   - {fileID: 1158418601}
   - {fileID: 1821561235}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6324,7 +6461,10 @@ MonoBehaviour:
   UsernameInputField: {fileID: 799349607}
   PasswordInputField: {fileID: 1842869059}
   LoggedInNameText: {fileID: 1788142563}
+  AppIdText: {fileID: 1633334064}
+  LobbyIdText: {fileID: 2034033206}
   ReconnectButton: {fileID: 1821561237}
+  JoinInProgressButton: {fileID: 1945819040}
   GameArea: {fileID: 571176152}
   StartGameBtn: {fileID: 93820288}
   EndGameBtn: {fileID: 365192645}
@@ -6556,12 +6696,12 @@ RectTransform:
   m_Children:
   - {fileID: 1991531371}
   m_Father: {fileID: 1061143994}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1100, y: -822.5}
-  m_SizeDelta: {x: 156.59998, y: 60}
+  m_AnchoredPosition: {x: 1235, y: -822.5}
+  m_SizeDelta: {x: 250, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &923297179
 MonoBehaviour:
@@ -7540,6 +7680,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 93820289}
+  - {fileID: 1945819038}
   - {fileID: 923297178}
   m_Father: {fileID: 1145382223}
   m_RootOrder: 4
@@ -7562,12 +7703,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
-    m_Left: 629
+    m_Left: 590
     m_Right: 663
     m_Top: 565
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 0
+  m_Spacing: 10
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 0
   m_ChildControlWidth: 0
@@ -8514,7 +8655,7 @@ RectTransform:
   - {fileID: 419693143}
   - {fileID: 597650700}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -11418,6 +11559,141 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 28}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &1633334061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1633334062}
+  - component: {fileID: 1633334065}
+  - component: {fileID: 1633334064}
+  m_Layer: 5
+  m_Name: AppID- Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1633334062
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633334061}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 658131628}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 69}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1633334064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633334061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'App ID: '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28.9
+  m_fontSizeBase: 28.9
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1633334065
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633334061}
+  m_CullTransparentMesh: 1
 --- !u!1 &1657251139
 GameObject:
   m_ObjectHideFlags: 0
@@ -13444,6 +13720,153 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ButtonColor: 5
+--- !u!1 &1945819037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1945819038}
+  - component: {fileID: 1945819042}
+  - component: {fileID: 1945819041}
+  - component: {fileID: 1945819040}
+  - component: {fileID: 1945819039}
+  m_Layer: 5
+  m_Name: JoinMatchInProgress - Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1945819038
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945819037}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 63417909}
+  m_Father: {fileID: 1061143994}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 975, y: -822.5}
+  m_SizeDelta: {x: 250, y: 90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1945819039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945819037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fc27ad93d49c8d4baff14770b9d773e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1945819040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945819037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1945819041}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 363795621}
+        m_TargetAssemblyTypeName: BrainCloudManager, Assembly-CSharp
+        m_MethodName: JoinMatch
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1945819041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945819037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6666667, g: 0.73333335, b: 0.8000001, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1945819042
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945819037}
+  m_CullTransparentMesh: 1
 --- !u!1 &1948750719
 GameObject:
   m_ObjectHideFlags: 0
@@ -13859,7 +14282,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Leave
+  m_text: Leave Lobby
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -14664,6 +15087,155 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2033874589}
   m_CullTransparentMesh: 1
+--- !u!1 &2034033203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2034033204}
+  - component: {fileID: 2034033207}
+  - component: {fileID: 2034033206}
+  - component: {fileID: 2034033205}
+  m_Layer: 5
+  m_Name: LobbyID-Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2034033204
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034033203}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 658131628}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -793, y: 69}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2034033205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034033203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95016f52e03808c4a97a7ff08d927e96, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  versionText: {fileID: 2034033206}
+--- !u!114 &2034033206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034033203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'LobbyId:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28.9
+  m_fontSizeBase: 28.9
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2034033207
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2034033203}
+  m_CullTransparentMesh: 1
 --- !u!1 &2055781960
 GameObject:
   m_ObjectHideFlags: 0
@@ -14832,7 +15404,7 @@ RectTransform:
   - {fileID: 1273693755}
   - {fileID: 1143324635}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -15154,7 +15726,7 @@ RectTransform:
   - {fileID: 1842869058}
   - {fileID: 820488706}
   m_Father: {fileID: 658131628}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/RelayTestApp/Assets/Scenes/main.unity
+++ b/RelayTestApp/Assets/Scenes/main.unity
@@ -2221,50 +2221,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 323421865}
   m_CullTransparentMesh: 1
---- !u!1 &332602408
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 332602410}
-  - component: {fileID: 332602409}
-  m_Layer: 0
-  m_Name: Logger
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &332602409
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 332602408}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fcade9ce03af3d94d835981cfff13068, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &332602410
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 332602408}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &334864971
 GameObject:
   m_ObjectHideFlags: 0
@@ -2305,6 +2261,7 @@ RectTransform:
   - {fileID: 22767412}
   - {fileID: 906921832}
   - {fileID: 819777836}
+  - {fileID: 365192646}
   m_Father: {fileID: 658131628}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2692,6 +2649,140 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &365192645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 365192646}
+  - component: {fileID: 365192649}
+  - component: {fileID: 365192648}
+  - component: {fileID: 365192647}
+  m_Layer: 5
+  m_Name: EndMatch - Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &365192646
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365192645}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 493412432}
+  m_Father: {fileID: 334864972}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 394, y: -851}
+  m_SizeDelta: {x: 161.4, y: 70.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &365192647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365192645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 365192648}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 363795621}
+        m_TargetAssemblyTypeName: BrainCloudManager, Assembly-CSharp
+        m_MethodName: EndMatch
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &365192648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365192645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.6666667, g: 0.73333335, b: 0.8000001, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &365192649
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 365192645}
+  m_CullTransparentMesh: 1
 --- !u!1 &376717216
 GameObject:
   m_ObjectHideFlags: 0
@@ -3430,6 +3521,143 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 467979204}
+  m_CullTransparentMesh: 1
+--- !u!1 &493412431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 493412432}
+  - component: {fileID: 493412434}
+  - component: {fileID: 493412433}
+  m_Layer: 5
+  m_Name: LeaveButton-Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &493412432
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493412431}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 365192646}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &493412433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493412431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'End Match
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 25.6
+  m_fontSizeBase: 25.6
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &493412434
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 493412431}
   m_CullTransparentMesh: 1
 --- !u!1 &504352191
 GameObject:
@@ -6061,6 +6289,17 @@ MonoBehaviour:
   CurrentGameState: 0
   LoadingGameState: {fileID: 438327805}
   ErrorMessage: {fileID: 2126129040}
+  CurrentLobby:
+    LobbyID: 
+    OwnerID: 
+    Members: []
+  CurrentServer:
+    Host: 
+    WsPort: 0
+    TcpPort: 0
+    UdpPort: 0
+    Passcode: 
+    LobbyId: 
   isReady: 0
   isLoading: 0
   Shockwaves: []
@@ -6088,8 +6327,19 @@ MonoBehaviour:
   ReconnectButton: {fileID: 1821561237}
   GameArea: {fileID: 571176152}
   StartGameBtn: {fileID: 93820288}
+  EndGameBtn: {fileID: 365192645}
   LobbyLocalUserText: {fileID: 504352193}
   CompressionDropdown: {fileID: 597650702}
+  _currentUserInfo:
+    ID: 
+    Username: 
+    AllowSendTo: 1
+    IsAlive: 0
+    UserGameColor: 0
+    MousePosition: {x: 0, y: 0}
+    ShockwavePositions: []
+    UserCursor: {fileID: 0}
+    cxId: 
 --- !u!4 &856249134
 Transform:
   m_ObjectHideFlags: 0
@@ -10974,6 +11224,50 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ButtonColor: 7
+--- !u!1 &1554208845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1554208847}
+  - component: {fileID: 1554208846}
+  m_Layer: 0
+  m_Name: Logger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1554208846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554208845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fcade9ce03af3d94d835981cfff13068, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1554208847
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1554208845}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.0789447, y: 0.27855945, z: -10.077874}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1572932326
 GameObject:
   m_ObjectHideFlags: 0

--- a/RelayTestApp/Assets/Scenes/main.unity
+++ b/RelayTestApp/Assets/Scenes/main.unity
@@ -3382,7 +3382,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1145382223}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -3825,7 +3825,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1145382223}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4725,7 +4725,7 @@ RectTransform:
   - {fileID: 106828037}
   - {fileID: 158759669}
   m_Father: {fileID: 1145382223}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7096,12 +7096,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1170092633}
-  m_RootOrder: 0
+  m_Father: {fileID: 1145382223}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 372, y: -227}
+  m_AnchoredPosition: {x: 372, y: -171.9}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &939792684
@@ -7683,7 +7683,7 @@ RectTransform:
   - {fileID: 1945819038}
   - {fileID: 923297178}
   m_Father: {fileID: 1145382223}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8649,6 +8649,7 @@ RectTransform:
   - {fileID: 684897319}
   - {fileID: 297105522}
   - {fileID: 1404745416}
+  - {fileID: 939792683}
   - {fileID: 1170092633}
   - {fileID: 1061143994}
   - {fileID: 504352192}
@@ -8983,10 +8984,9 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 939792683}
+  m_Children: []
   m_Father: {fileID: 1145382223}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/RelayTestApp/Assets/Scenes/main.unity
+++ b/RelayTestApp/Assets/Scenes/main.unity
@@ -2756,7 +2756,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c1d2c9bcbbbd7b4eb4da0b4fb906883, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LeavingGame: 0
 --- !u!114 &363795622
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4252,7 +4251,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 681431543}
   m_Father: {fileID: 1428864173}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5060,6 +5060,120 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1001 &681431542
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 542247947}
+    m_Modifications:
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 229.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6912.0005
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 136.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -30.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123397, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123397, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 155.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123400, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_text
+      value: '[username] Is In Lobby'
+      objectReference: {fileID: 0}
+    - target: {fileID: 4362776453284123451, guid: 72f3d017020aee145adcf92366166211, type: 3}
+      propertyPath: m_Name
+      value: UserEntryMatch -TextToggle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 72f3d017020aee145adcf92366166211, type: 3}
+--- !u!224 &681431543 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4362776453284123395, guid: 72f3d017020aee145adcf92366166211, type: 3}
+  m_PrefabInstance: {fileID: 681431542}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &684897318
 GameObject:
   m_ObjectHideFlags: 0
@@ -6480,6 +6594,7 @@ MonoBehaviour:
     ShockwavePositions: []
     UserCursor: {fileID: 0}
     cxId: 
+    IsReady: 0
 --- !u!4 &856249134
 Transform:
   m_ObjectHideFlags: 0

--- a/RelayTestApp/Assets/Scripts/Data/Lobby.cs
+++ b/RelayTestApp/Assets/Scripts/Data/Lobby.cs
@@ -1,8 +1,7 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
-using BrainCloud;
-using UnityEngine;
 
+[Serializable]
 public class Lobby
 {
     public string LobbyID;
@@ -27,7 +26,7 @@ public class Lobby
             {
                 user.AllowSendTo = false;
             }
-
+            user.IsAlive = true;
             if (user.ID.Equals(OwnerID))
             {
                 Dictionary<string, object> extra = jsonMember["extra"] as Dictionary<string, object>;
@@ -39,6 +38,18 @@ public class Lobby
             }
             Members.Add(user);
         }
+    }
+
+    public string ReassignOwnerID(string id)
+    {
+        OwnerID = FormatOwnerID(id);
+
+        return OwnerID;
+    }
+
+    public string FormatCxIdToProfileId(string id)
+    {
+        return FormatOwnerID(id);
     }
 
     private string FormatOwnerID(string id)

--- a/RelayTestApp/Assets/Scripts/Data/Server.cs
+++ b/RelayTestApp/Assets/Scripts/Data/Server.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[Serializable]
 public class Server
 {
     public string Host;
@@ -10,7 +12,7 @@ public class Server
     public int UdpPort = -1;
     public string Passcode;
     public string LobbyId;
-
+    
     public Server(Dictionary<string, object> serverJson)
     {
         var connectData = serverJson["connectData"] as Dictionary<string, object>;

--- a/RelayTestApp/Assets/Scripts/Data/UserInfo.cs
+++ b/RelayTestApp/Assets/Scripts/Data/UserInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -5,6 +6,7 @@ using UnityEngine;
 /// Holds all the information needed from a User
 /// </summary>
 
+[Serializable]
 public class UserInfo
 {
     //Used to know if local user is hosting

--- a/RelayTestApp/Assets/Scripts/Data/UserInfo.cs
+++ b/RelayTestApp/Assets/Scripts/Data/UserInfo.cs
@@ -27,6 +27,8 @@ public class UserInfo
     public UserCursor UserCursor;
     public UserInfo() { }
     public string cxId;
+    //Used to determine if user is in lobby or in match.
+    public bool IsReady;
     public UserInfo(Dictionary<string, object> userJson)
     {
         cxId = userJson["cxId"] as string;
@@ -35,5 +37,6 @@ public class UserInfo
         Dictionary<string, object> extra = userJson["extra"] as Dictionary<string, object>;
         int colorIndex = (int)extra["colorIndex"];
         UserGameColor = (GameColors) colorIndex;
+        IsReady = (bool)userJson["isReady"];
     }
 }

--- a/RelayTestApp/Assets/Scripts/Managers/BrainCloudManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/BrainCloudManager.cs
@@ -213,6 +213,7 @@ public class BrainCloudManager : MonoBehaviour
     public void JoinMatch()
     {
         StateManager.Instance.ButtonPressed_ChangeState(GameStates.Lobby);
+        GameManager.Instance.JoinInProgressButton.gameObject.SetActive(false);
         ConnectRelay();
     }
 
@@ -319,7 +320,6 @@ public class BrainCloudManager : MonoBehaviour
                 break;
         }
     }
-    
 
 #endregion Input update
 
@@ -441,6 +441,10 @@ public class BrainCloudManager : MonoBehaviour
                     {
                         ConnectRelay();    
                     }
+                    else
+                    {
+                        GameManager.Instance.JoinInProgressButton.gameObject.SetActive(true);
+                    }
                     break;
             }
         }
@@ -504,6 +508,8 @@ public class BrainCloudManager : MonoBehaviour
         else if (json["op"] as string == "CONNECT")
         {
             StateManager.Instance.isLoading = false;
+            //Check if user connected is new, if so update name to not have "In Lobby" 
+            GameManager.Instance.UpdateMatchState();
         }
         else if (json["op"] as string == "END_MATCH")
         {

--- a/RelayTestApp/Assets/Scripts/Managers/BrainCloudManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/BrainCloudManager.cs
@@ -134,7 +134,7 @@ public class BrainCloudManager : MonoBehaviour
     {
         if (m_dead) return;
 
-        if (jsonError.Contains("Disconnected by server from end match message"))
+        if (reasonCode == ReasonCodes.RS_ENDMATCH_REQUESTED)
         {
             return;
         }
@@ -199,7 +199,11 @@ public class BrainCloudManager : MonoBehaviour
     public void EndMatch()
     {
         GameManager.Instance.UpdateLobbyState();
-        m_bcWrapper.RelayService.EndMatch();
+        Dictionary<string, object> json = new Dictionary<string, object>();
+        json["cxId"] = m_bcWrapper.Client.RTTConnectionID;
+        json["lobbyId"] = StateManager.Instance.CurrentLobby.LobbyID;
+        json["op"] = "END_MATCH";
+        m_bcWrapper.RelayService.EndMatch(json);
     }
 
     public void ReconnectUser()

--- a/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -28,7 +29,10 @@ public class GameManager : MonoBehaviour
     public TMP_InputField UsernameInputField;
     public TMP_InputField PasswordInputField;
     public TMP_Text LoggedInNameText;
+    public TMP_Text AppIdText;
+    public TMP_Text LobbyIdText;
     public Button ReconnectButton;
+    public Button JoinInProgressButton;
     //for updating members list of shockwaves
     public GameArea GameArea;  
     //local user's start button for starting a match
@@ -54,6 +58,8 @@ public class GameManager : MonoBehaviour
         set => _currentUserInfo = value;
     }
     
+    public void ActivateJoinMatchButton() => JoinInProgressButton.gameObject.SetActive(true);
+    
     private void Awake()
     {
         if (!_instance)
@@ -65,13 +71,16 @@ public class GameManager : MonoBehaviour
             Destroy(gameObject);
         }
         ReconnectButton.gameObject.SetActive(false);
+        JoinInProgressButton.gameObject.SetActive(false);
         _eventSystem = EventSystem.current;
         PasswordInputField.inputType = TMP_InputField.InputType.Password;
         LoadPlayerSettings();
+        LobbyIdText.enabled = false;
+        AppIdText.text = $"App ID: {BrainCloud.Plugin.Interface.AppId}";
     }
 
     // Update is called once per frame
-    void Update()
+    private void Update()
     {
         if (Input.GetKeyDown(KeyCode.Tab))
         {
@@ -151,7 +160,7 @@ public class GameManager : MonoBehaviour
         for (int i = 0; i < lobby.Members.Count; i++)
         {
             UserCursor newCursor = Instantiate(UserCursorPrefab, Vector3.zero, Quaternion.identity, UserCursorParent.transform);
-            
+            lobby.Members[i].MousePosition = new Vector2(9999, 9999);
             newCursor.AdjustVisibility(false);
             newColor = ReturnUserColor(lobby.Members[i].UserGameColor);
             newCursor.SetUpCursor(newColor,lobby.Members[i].Username);
@@ -169,6 +178,11 @@ public class GameManager : MonoBehaviour
         StartGameBtn.SetActive(IsLocalUserHost());
         EndGameBtn.SetActive(IsLocalUserHost());
         CompressionDropdown.interactable = IsLocalUserHost();
+        LobbyIdText.text = $"Lobby ID: {StateManager.Instance.CurrentLobby.LobbyID}";
+        if (!LobbyIdText.enabled)
+        {
+            LobbyIdText.enabled = true;
+        }
     }
 
     public void UpdateMatchAndLobbyState()

--- a/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
@@ -58,8 +58,6 @@ public class GameManager : MonoBehaviour
         set => _currentUserInfo = value;
     }
     
-    public void ActivateJoinMatchButton() => JoinInProgressButton.gameObject.SetActive(true);
-    
     private void Awake()
     {
         if (!_instance)
@@ -172,11 +170,33 @@ public class GameManager : MonoBehaviour
             }
         }
     }
+
+    public void ClearMatchEntries()
+    { 
+        if (_matchEntries.Count > 0)
+        {
+            foreach (UserEntry matchEntry in _matchEntries)
+            {
+                Destroy(matchEntry.gameObject);
+            }
+            _matchEntries.Clear();    
+        }
+    }
+    
     public void UpdateLobbyState()
     {   
         AdjustEntryList(UserEntryLobbyParent.transform,UserEntryLobbyPrefab);
         StartGameBtn.SetActive(IsLocalUserHost());
         EndGameBtn.SetActive(IsLocalUserHost());
+        if (!StartGameBtn.gameObject.activeSelf &&
+            !BrainCloudManager.Instance.PresentWhileStarted)
+        {
+            JoinInProgressButton.gameObject.SetActive(true);
+        }
+        else
+        {
+            JoinInProgressButton.gameObject.SetActive(false);
+        }
         CompressionDropdown.interactable = IsLocalUserHost();
         LobbyIdText.text = $"Lobby ID: {StateManager.Instance.CurrentLobby.LobbyID}";
         if (!LobbyIdText.enabled)
@@ -201,13 +221,14 @@ public class GameManager : MonoBehaviour
 
     private void AdjustEntryList(Transform parent, UserEntry prefab)
     {
-        if (_matchEntries.Count > 0)
+        //Clean up any child objects in parent
+        if (parent.childCount > 0)
         {
-            foreach (UserEntry matchEntry in _matchEntries)
+            for (int i = 0; i < parent.childCount; ++i)
             {
-                Destroy(matchEntry.gameObject);   
+                Transform child = parent.GetChild(i);
+                Destroy(child.gameObject);
             }
-            _matchEntries.Clear();    
         }
         
         //populate user entries based on members in lobby
@@ -218,7 +239,7 @@ public class GameManager : MonoBehaviour
             {
                 var newEntry = Instantiate(prefab, Vector3.zero, Quaternion.identity,parent);
                 SetUpUserEntry(lobby.Members[i], newEntry);
-                _matchEntries.Add(newEntry);   
+                _matchEntries.Add(newEntry);
             }    
         }
 

--- a/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/GameManager.cs
@@ -33,6 +33,7 @@ public class GameManager : MonoBehaviour
     public GameArea GameArea;  
     //local user's start button for starting a match
     public GameObject StartGameBtn;
+    public GameObject EndGameBtn;
     public TMP_Text LobbyLocalUserText;
     public TMP_Dropdown CompressionDropdown;
     private EventSystem _eventSystem;
@@ -45,6 +46,7 @@ public class GameManager : MonoBehaviour
     public static GameManager Instance => _instance;
     
     //Local User Info
+    [SerializeField]
     private UserInfo _currentUserInfo;
     public UserInfo CurrentUserInfo
     {
@@ -165,7 +167,14 @@ public class GameManager : MonoBehaviour
     {   
         AdjustEntryList(UserEntryLobbyParent.transform,UserEntryLobbyPrefab);
         StartGameBtn.SetActive(IsLocalUserHost());
+        EndGameBtn.SetActive(IsLocalUserHost());
         CompressionDropdown.interactable = IsLocalUserHost();
+    }
+
+    public void UpdateMatchAndLobbyState()
+    {
+        UpdateLobbyState();
+        UpdateMatchState();
     }
     
     /// <summary>
@@ -191,9 +200,12 @@ public class GameManager : MonoBehaviour
         Lobby lobby = StateManager.Instance.CurrentLobby;
         for (int i = 0; i < lobby.Members.Count; i++)
         {
-            var newEntry = Instantiate(prefab, Vector3.zero, Quaternion.identity,parent);
-            SetUpUserEntry(lobby.Members[i], newEntry);
-            _matchEntries.Add(newEntry);    
+            if (lobby.Members[i].IsAlive)
+            {
+                var newEntry = Instantiate(prefab, Vector3.zero, Quaternion.identity,parent);
+                SetUpUserEntry(lobby.Members[i], newEntry);
+                _matchEntries.Add(newEntry);   
+            }    
         }
 
         LobbyLocalUserText.text = _currentUserInfo.Username;
@@ -226,12 +238,6 @@ public class GameManager : MonoBehaviour
         {
             CurrentUserInfo.AllowSendTo = isVisible;
         }
-    }
-    
-    public void MemberLeft()
-    {
-        UpdateMatchState();
-        UpdateCursorList();
     }
 
     public void EmptyCursorList()

--- a/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
@@ -21,13 +21,13 @@ public class StateManager : MonoBehaviour
     public GameStates CurrentGameState;
     public ConnectingGameState LoadingGameState;
     public DialogueMessage ErrorMessage;
+    
     //Network info needed
     [SerializeField]
     public Lobby CurrentLobby;
     [SerializeField]
     public Server CurrentServer;
     internal RelayConnectionType Protocol { get; set; }
-    
     
     //Specific for loading and waiting
     public bool isReady;
@@ -76,14 +76,12 @@ public class StateManager : MonoBehaviour
 
     IEnumerator DelayToDisconnect()
     {
-        BrainCloudManager.Instance.LeavingGame = true;
         yield return new WaitForSeconds(0.2f);
-        
+        GameManager.Instance.LobbyIdText.enabled = false;
         BrainCloudManager.Instance.CloseGame();
         ChangeState(GameStates.MainMenu);
         ResetData();
         yield return new WaitForFixedUpdate();
-        BrainCloudManager.Instance.LeavingGame = false;
     }
 
     public void LeaveMatchBackToMenu()

--- a/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
@@ -22,7 +22,9 @@ public class StateManager : MonoBehaviour
     public ConnectingGameState LoadingGameState;
     public DialogueMessage ErrorMessage;
     //Network info needed
+    [SerializeField]
     public Lobby CurrentLobby;
+    [SerializeField]
     public Server CurrentServer;
     internal RelayConnectionType Protocol { get; set; }
     

--- a/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
+++ b/RelayTestApp/Assets/Scripts/Managers/StateManager.cs
@@ -88,6 +88,7 @@ public class StateManager : MonoBehaviour
 
     public void LeaveMatchBackToMenu()
     {
+        GameManager.Instance.LobbyIdText.enabled = false;
         ResetData();
         ChangeState(GameStates.SignIn);
     }

--- a/RelayTestApp/Assets/Scripts/Match/GameArea.cs
+++ b/RelayTestApp/Assets/Scripts/Match/GameArea.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -61,6 +62,14 @@ public class GameArea : MonoBehaviour
         }
         UpdateAllCursorsMovement();
         UpdateAllShockwaves();
+    }
+
+    private void OnDisable()
+    {
+        if (!Cursor.visible)
+        {
+            Cursor.visible = true;    
+        }
     }
 
     private void UpdateAllShockwaves()

--- a/RelayTestApp/Assets/Scripts/UserPrefab/UserCursor.cs
+++ b/RelayTestApp/Assets/Scripts/UserPrefab/UserCursor.cs
@@ -1,7 +1,9 @@
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
+[Serializable]
 public class UserCursor : MonoBehaviour
 {
     public TMP_Text UsernameText;

--- a/RelayTestApp/Assets/Scripts/UserPrefab/UserEntry.cs
+++ b/RelayTestApp/Assets/Scripts/UserPrefab/UserEntry.cs
@@ -1,7 +1,9 @@
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
+[Serializable]
 public class UserEntry : MonoBehaviour
 {
     public TMP_Text UsernameText;

--- a/RelayTestApp/ProjectSettings/BurstAotSettings_StandaloneWindows.json
+++ b/RelayTestApp/ProjectSettings/BurstAotSettings_StandaloneWindows.json
@@ -1,0 +1,17 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "UsePlatformSDKLinker": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX32": 6,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/RelayTestApp/ProjectSettings/CommonBurstAotSettings.json
+++ b/RelayTestApp/ProjectSettings/CommonBurstAotSettings.json
@@ -1,0 +1,6 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "DisabledWarnings": ""
+  }
+}

--- a/RelayTestApp/ProjectSettings/ProjectSettings.asset
+++ b/RelayTestApp/ProjectSettings/ProjectSettings.asset
@@ -156,7 +156,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.Bitheads.RelayTestApp
-    Standalone: com.Bitheads.RelayTestApp
+    Standalone: com.bc.RelayTestApp
   buildNumber:
     Standalone: 0
     iPhone: 0

--- a/RelayTestApp/ProjectSettings/SceneTemplateSettings.json
+++ b/RelayTestApp/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,167 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "ignore": false,
+        "defaultInstantiationMode": 1,
+        "supportsModification": true
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
Summary of changes:
- Implemented END_MATCH to demonstrate closing a room and returning to lobby.
- When host is disconnected, the button for sending END_MATCH is enabled for the new host.
- Included a JSON payload for END_MATCH requests.
- Added a Join Match button for users when they join a lobby while a room has been launched, users in match will show the new user is in lobby and when the user joins it will just display the name. 
- Bug fixes for updating Lobby and Match states. 